### PR TITLE
FEM-1753 Added retry mechanism to the Request Executor

### DIFF
--- a/NetKit/Classes/Core/Request/KalturaMultiRequestBuilder.swift
+++ b/NetKit/Classes/Core/Request/KalturaMultiRequestBuilder.swift
@@ -17,6 +17,17 @@ public class KalturaMultiRequestBuilder: KalturaRequestBuilder {
         super.init(url: url, service: "multirequest", action: nil)
     }
     
+    public override var description: String {
+        var string = ""
+        for request in requests {
+            string.append("[")
+            string.append(request.description)
+            string.append("\n]\n")
+        }
+        
+        return string
+    }
+    
     @discardableResult
     public func add(request:KalturaRequestBuilder) -> Self {
         self.requests.append(request)

--- a/NetKit/Classes/Core/Request/KalturaRequestBuilder.swift
+++ b/NetKit/Classes/Core/Request/KalturaRequestBuilder.swift
@@ -37,8 +37,9 @@ public class KalturaRequestBuilder: RequestBuilder {
         
         self.add(headerKey: "Content-Type", headerValue: "application/json").add(headerKey: "Accept", headerValue: "application/json")
         self.set(method: .post)
-        
     }
        
-
+    public override var description: String {
+        return super.description + "\nService: \(service ?? "")\nAction: \(action ?? "")"
+    }
 }

--- a/NetKit/Classes/Core/Request/Request.swift
+++ b/NetKit/Classes/Core/Request/Request.swift
@@ -73,6 +73,10 @@ public struct RequestElement: Request {
         }
     }
     
+    public override var description: String {
+        return "\nMethod: \(method?.value ?? "")\nURL: \(url.description)\nParams: \(urlParams?.description ?? "")\nBody: \(jsonBody ?? "")"
+    }
+    
     @discardableResult
     public func set(url: URL) -> Self{
         self.url = url

--- a/NetKit/Classes/Core/Request/RequestConfiguration.swift
+++ b/NetKit/Classes/Core/Request/RequestConfiguration.swift
@@ -10,17 +10,13 @@ import UIKit
 
 
 var defaultTimeOut = 3.0
-var defaultRetryCount = 3
+var defaultRetryCount = 4
 
-public class RequestConfiguration {
+@objc public class RequestConfiguration: NSObject {
 
     public var readTimeOut: Double = defaultTimeOut
     public var writeTimeOut: Double = defaultTimeOut
     public var connectTimeOut: Double = defaultTimeOut
-    public var retryCount: Int = defaultRetryCount
-    public var ignoreLocalCache: Bool = false
-    
-    public init() {
-        
-    }
+    @objc public var retryCount: Int = defaultRetryCount
+    @objc public var ignoreLocalCache: Bool = false
 }


### PR DESCRIPTION
Added retry mechanism to the Request Executor in case of http response codes 400 - 599.

Added an option to set the default request configuration for all the requests.
In case there is a request configuration set on the request itself the executor will use that configuration.
Fixed the data task response logic to return the correct data to the completion block.
Added missing clean function for the executor once the request was done.
Added a description function to the KalturaMultiRequestBuilder, KalturaRequestBuilder, and the RequestBuilder for easier debugging and logging.
Updated the RequestConfiguration, defaultRetryCount to 4, and set it to be exposed to ObjC.