### PR TITLE
FEC-11631 Replace 'class' keyword to define a class-constrained protocol to 'AnyObject'

### DIFF
--- a/NetKit/Classes/Core/Session/SessionProvider.swift
+++ b/NetKit/Classes/Core/Session/SessionProvider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-@objc public protocol SessionProvider: class {
+@objc public protocol SessionProvider: AnyObject {
     
     var serverURL: String { get }
     var partnerId: Int64 { get }


### PR DESCRIPTION
FEC-11631
Replace 'class' keyword to define a class-constrained protocol to 'AnyObject'